### PR TITLE
fix: add package license metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@konsumation/cloudflare-worker",
       "version": "0.0.0-semantic-release",
+      "license": "BSD-2-Clause",
       "dependencies": {
         "@tsndr/cloudflare-worker-jwt": "^3.1.1",
         "crypto-js": "^4.1.1",
@@ -6892,6 +6893,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "packageManager": "npm@11.6.3+sha512.4085a763162e0e3acd19a4e9d23ad3aa0978e501ccf947dd7233c12a689ae0bb0190763c4ef12366990056b34eec438903ffed38fde4fbd722a17c2a7407ee92",
   "main": "src/index.mjs",
   "description": "konsum api in a cloudflare worker",
+  "license": "BSD-2-Clause",
   "contributors": [
     {
       "name": "Markus Felten",


### PR DESCRIPTION
## Summary
- adds the missing npm `license` metadata for `@konsumation/cloudflare-worker`
- uses `BSD-2-Clause`, matching the repository root `LICENSE`

## Validation
- `node` metadata assertion confirms `package.json` has `license: "BSD-2-Clause"` and the root license file is BSD 2-Clause
- `npm install --ignore-scripts --no-audit --no-fund`
- `npm pack --dry-run --json`
- `git diff --check`
