### PR TITLE
fix: add license MIT to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,5 +65,6 @@
       "arlac77/template-wrangler",
       "konsumation/template"
     ]
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
The published `@konsumation/cloudflare-worker` npm package is missing `license` metadata.

**Changes:**
- Add `"license": "MIT"` to `package.json`

Related: https://github.com/charles-openclaw/charles-microbounties/issues/791